### PR TITLE
Update intel driver versions on 24.04

### DIFF
--- a/apps/fileflows/Dockerfile
+++ b/apps/fileflows/Dockerfile
@@ -74,7 +74,11 @@ RUN apt-get update \
         curl -LO https://github.com/intel/intel-graphics-compiler/releases/download/v2.11.7/intel-igc-core-2_2.11.7+19146_amd64.deb && \
         curl -LO https://github.com/intel/intel-graphics-compiler/releases/download/v2.11.7/intel-igc-opencl-2_2.11.7+19146_amd64.deb && \
         curl -LO https://github.com/intel/compute-runtime/releases/download/25.13.33276.16/intel-opencl-icd_25.13.33276.16_amd64.deb && \
-        dpkg -i --force-all ./*.deb && \
+        && apt-get install -y --no-install-recommends --no-install-suggests \
+            ./libigdgmm12_22.7.0_amd64.deb \
+            ./intel-igc-core-2_2.11.7+19146_amd64.deb \
+            ./intel-igc-opencl-2_2.11.7+19146_amd64.deb \
+            ./intel-opencl-icd_25.13.33276.16_amd64.deb \
         cd /; \
     fi \
     && VERSION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d= -f2) \

--- a/apps/fileflows/Dockerfile
+++ b/apps/fileflows/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/ubuntu:24.10 AS fileflows-download
+FROM docker.io/library/ubuntu:24.04 AS fileflows-download
 ARG VERSION
 
 ENV DEBIAN_FRONTEND="noninteractive" \
@@ -33,7 +33,7 @@ RUN \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-FROM docker.io/library/ubuntu:24.10 AS runtime
+FROM docker.io/library/ubuntu:24.04 AS runtime
 ARG TARGETARCH
 ARG VENDOR
 ARG VERSION
@@ -53,22 +53,38 @@ ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility" \
     PORT="5000"
 
 USER root
-WORKDIR /app
 
 COPY --from=fileflows-download /app /app
 
 # hadolint ignore=DL3008,DL3015,SC2039,SC2086
 RUN \
     apt-get update && apt-get install -y --no-install-recommends --no-install-suggests \
+        # Can uninstall before build
         apt-transport-https \
         curl \
-        ca-certificates \
         gnupg \
+        # Needed for FF to run
+        aspnetcore-runtime-8.0 \
+        ca-certificates \
+        catatonit \
+        libfontconfig1 \
+        libfreetype6 \
+        pciutils \
+    # Intel HW
+    if [ "${TARGETARCH}" = "amd64" ] then \
+      mkdir -p /tmp/intel-compute-runtime && cd /tmp/intel-compute-runtime \
+      && curl -LO https://github.com/intel/compute-runtime/releases/download/25.13.33276.16/libigdgmm12_22.7.0_amd64.deb \
+      && curl -LO https://github.com/intel/intel-graphics-compiler/releases/download/v2.11.7/intel-igc-core-2_2.11.7+19146_amd64.deb \
+      && curl -LO https://github.com/intel/intel-graphics-compiler/releases/download/v2.11.7/intel-igc-opencl-2_2.11.7+19146_amd64.deb \
+      && curl -LO https://github.com/intel/compute-runtime/releases/download/25.13.33276.16/intel-opencl-icd_25.13.33276.16_amd64.deb \
+      && dpkg -i --force-all ./*.deb \
+      && cd / \
+    fi \
     # Install ffmpeg
     && VERSION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d= -f2) \
     && curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key \
         | gpg --dearmor -o /etc/apt/trusted.gpg.d/jellyfin_team.gpg \
-    && echo "deb [arch=${TARGETARCH}] https://repo.jellyfin.org/ubuntu noble main" \
+    && echo "deb [arch=${TARGETARCH}] https://repo.jellyfin.org/ubuntu ${VERSION_CODENAME} main" \
         > /etc/apt/sources.list.d/jellyfin.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends --no-install-suggests \
@@ -77,23 +93,6 @@ RUN \
     && ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/local/bin/ffmpeg \
     && ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/local/bin/ffmpeg7 \
     && ln -s /usr/lib/jellyfin-ffmpeg/ffprobe /usr/local/bin/ffprobe \
-    # Needed for FF to run
-    && apt-get update && apt-get install -y --no-install-recommends --no-install-suggests \
-        aspnetcore-runtime-8.0 \
-        catatonit \
-        libfontconfig1 \
-        libfreetype6 \
-        pciutils \
-        # Intel HW
-        vainfo \
-        libva2 \
-    && \
-        if [ "${TARGETARCH}" = "amd64" ]; then \
-            apt-get install -y --no-install-recommends --no-install-suggests \
-                intel-media-va-driver-non-free \
-                i965-va-driver-shaders \
-                libmfx-gen1.2; \
-        fi \
     # Clean up unnecessary packages
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
         apt-transport-https \
@@ -102,13 +101,14 @@ RUN \
     && apt-get autoremove -y \
     && apt-get clean \
     # Clean up image
-    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /var/lib/apt/lists/* /tmp/* \
     # i18n hack
     && mkdir -p /var/tmp/i18n && mv /app/Server/wwwroot/i18n/* /var/tmp/i18n
 
 COPY . /
 RUN chmod +x /entrypoint.sh
 
+WORKDIR /app
 USER nobody:nogroup
 VOLUME ["/app/Data"]
 

--- a/apps/fileflows/Dockerfile
+++ b/apps/fileflows/Dockerfile
@@ -75,7 +75,7 @@ RUN \
     && echo "deb [arch=${TARGETARCH}] http://archive.ubuntu.com/ubuntu oracular main universe" \
         > /etc/apt/sources.list.d/oracular.list \
     && printf "Package: libva2\nPin: release n=oracular\nPin-Priority: 990\n" \
-        > /etc/apt/preferences.d/99-libva-pin.pref; \
+        > /etc/apt/preferences.d/99-libva-pin.pref \
     && apt-get update && apt-get install -y --no-install-recommends --no-install-suggests \
         libva2 \
     # Intel HW

--- a/apps/fileflows/Dockerfile
+++ b/apps/fileflows/Dockerfile
@@ -72,8 +72,10 @@ RUN \
         libfreetype6 \
         pciutils \
     # libva 2.20 needed for jellyfin-ffmpeg
-    && echo "deb [arch=${TARGETARCH}] http://archive.ubuntu.com/ubuntu oracular main universe" \
+    && echo "deb [arch=amd64] http://archive.ubuntu.com/ubuntu oracular main universe" \
         > /etc/apt/sources.list.d/oracular.list \
+    && echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports oracular main universe" \
+        >> /etc/apt/sources.list.d/oracular.list \
     && printf "Package: libva2\nPin: release n=oracular\nPin-Priority: 990\n" \
         > /etc/apt/preferences.d/99-libva-pin.pref \
     && apt-get update && apt-get install -y --no-install-recommends --no-install-suggests \

--- a/apps/fileflows/Dockerfile
+++ b/apps/fileflows/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/ubuntu:24.04 AS fileflows-download
+FROM docker.io/library/ubuntu:24.10 AS fileflows-download
 ARG VERSION
 
 ENV DEBIAN_FRONTEND="noninteractive" \
@@ -33,7 +33,7 @@ RUN \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-FROM docker.io/library/ubuntu:24.04 AS runtime
+FROM docker.io/library/ubuntu:24.10 AS runtime
 ARG TARGETARCH
 ARG VENDOR
 ARG VERSION
@@ -64,16 +64,11 @@ RUN \
         curl \
         ca-certificates \
         gnupg \
-    # Add intel repos for up-to-date drivers
-    && VERSION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d= -f2) \
-    && curl -fsSL https://repositories.intel.com/graphics/intel-graphics.key \
-        | gpg --dearmor -o /etc/apt/trusted.gpg.d/intel-graphics.gpg \
-    && echo "deb [arch=${TARGETARCH}] https://repositories.intel.com/graphics/ubuntu jammy main" \
-        > /etc/apt/sources.list.d/intel-graphics.list \
     # Install ffmpeg
+    && VERSION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d= -f2) \
     && curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key \
         | gpg --dearmor -o /etc/apt/trusted.gpg.d/jellyfin_team.gpg \
-    && echo "deb [arch=${TARGETARCH}] https://repo.jellyfin.org/ubuntu ${VERSION_CODENAME} main" \
+    && echo "deb [arch=${TARGETARCH}] https://repo.jellyfin.org/ubuntu noble main" \
         > /etc/apt/sources.list.d/jellyfin.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends --no-install-suggests \

--- a/apps/fileflows/Dockerfile
+++ b/apps/fileflows/Dockerfile
@@ -53,29 +53,40 @@ ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility" \
     PORT="5000"
 
 USER root
+WORKDIR /app
 
 COPY --from=fileflows-download /app /app
 
 # hadolint ignore=DL3008,DL3015,SC2039,SC2086
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends --no-install-suggests \
+RUN \
+    apt-get update && apt-get install -y --no-install-recommends --no-install-suggests \
+        # Can uninstall before build
         apt-transport-https \
         curl \
         gnupg \
+        # Needed for FF to run
         aspnetcore-runtime-8.0 \
         ca-certificates \
         catatonit \
         libfontconfig1 \
         libfreetype6 \
         pciutils \
-    && if [ "${TARGETARCH}" = "amd64" ]; then \
-        mkdir -p /tmp/intel-compute-runtime \
-        && curl -Lo /tmp/intel-compute-runtime/libigdgmm.deb https://github.com/intel/compute-runtime/releases/download/25.13.33276.16/libigdgmm12_22.7.0_amd64.deb \
-        && curl -Lo /tmp/intel-compute-runtime/intel-igc-core.deb https://github.com/intel/intel-graphics-compiler/releases/download/v2.10.8/intel-igc-core-2_2.11.7+19146_amd64.deb \
-        && curl -Lo /tmp/intel-compute-runtime/intel-igc-opencl.deb https://github.com/intel/intel-graphics-compiler/releases/download/v2.10.8/intel-igc-opencl-2_2.11.7+19146_amd64.deb \
-        && curl -Lo /tmp/intel-compute-runtime/intel-opencl-icd.deb https://github.com/intel/compute-runtime/releases/download/25.13.33276.16/intel-opencl-icd_25.13.33276.16_amd64.deb \
-        && apt-get install -y --no-install-recommends /tmp/intel-compute-runtime/*.deb; \
-    fi \
+    # libva 2.20 needed for jellyfin-ffmpeg
+    && echo "deb [arch=${TARGETARCH}] http://archive.ubuntu.com/ubuntu oracular main universe" \
+        > /etc/apt/sources.list.d/oracular.list \
+    && printf "Package: libva2\nPin: release n=oracular\nPin-Priority: 990\n" \
+        > /etc/apt/preferences.d/99-libva-pin.pref; \
+    && apt-get update && apt-get install -y --no-install-recommends --no-install-suggests \
+        libva2 \
+    # Intel HW
+    && \
+        if [ "${TARGETARCH}" = "amd64" ]; then \
+            apt-get install -y --no-install-recommends --no-install-suggests \
+                intel-media-va-driver-non-free \
+                i965-va-driver-shaders \
+                libmfx-gen1.2; \
+        fi \
+    # Install ffmpeg
     && VERSION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d= -f2) \
     && curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key \
         | gpg --dearmor -o /etc/apt/trusted.gpg.d/jellyfin_team.gpg \
@@ -84,23 +95,25 @@ RUN apt-get update \
     && apt-get update \
     && apt-get install -y --no-install-recommends --no-install-suggests \
         jellyfin-ffmpeg7 \
+    # ffmpeg link
     && ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/local/bin/ffmpeg \
     && ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/local/bin/ffmpeg7 \
     && ln -s /usr/lib/jellyfin-ffmpeg/ffprobe /usr/local/bin/ffprobe \
+    # Clean up unnecessary packages
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
         apt-transport-https \
         curl \
         gnupg \
     && apt-get autoremove -y \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* \
+    # Clean up image
+    && rm -rf /var/lib/apt/lists/* \
+    # i18n hack
     && mkdir -p /var/tmp/i18n && mv /app/Server/wwwroot/i18n/* /var/tmp/i18n
-
 
 COPY . /
 RUN chmod +x /entrypoint.sh
 
-WORKDIR /app
 USER nobody:nogroup
 VOLUME ["/app/Data"]
 

--- a/apps/fileflows/Dockerfile
+++ b/apps/fileflows/Dockerfile
@@ -71,8 +71,8 @@ RUN apt-get update \
     && if [ "${TARGETARCH}" = "amd64" ]; then \
         mkdir -p /tmp/intel-compute-runtime \
         && curl -Lo /tmp/intel-compute-runtime/libigdgmm.deb https://github.com/intel/compute-runtime/releases/download/25.13.33276.16/libigdgmm12_22.7.0_amd64.deb \
-        && curl -Lo /tmp/intel-compute-runtime/intel-igc-core.deb https://github.com/intel/intel-graphics-compiler/releases/download/v2.11.7/intel-igc-core-2_2.11.7+19146_amd64.deb \
-        && curl -Lo /tmp/intel-compute-runtime/intel-igc-opencl.deb https://github.com/intel/intel-graphics-compiler/releases/download/v2.11.7/intel-igc-opencl-2_2.11.7+19146_amd64.deb \
+        && curl -Lo /tmp/intel-compute-runtime/intel-igc-core.deb https://github.com/intel/intel-graphics-compiler/releases/download/v2.10.8/intel-igc-core-2_2.11.7+19146_amd64.deb \
+        && curl -Lo /tmp/intel-compute-runtime/intel-igc-opencl.deb https://github.com/intel/intel-graphics-compiler/releases/download/v2.10.8/intel-igc-opencl-2_2.11.7+19146_amd64.deb \
         && curl -Lo /tmp/intel-compute-runtime/intel-opencl-icd.deb https://github.com/intel/compute-runtime/releases/download/25.13.33276.16/intel-opencl-icd_25.13.33276.16_amd64.deb \
         && apt-get install -y --no-install-recommends /tmp/intel-compute-runtime/*.deb; \
     fi \

--- a/apps/fileflows/Dockerfile
+++ b/apps/fileflows/Dockerfile
@@ -57,30 +57,26 @@ USER root
 COPY --from=fileflows-download /app /app
 
 # hadolint ignore=DL3008,DL3015,SC2039,SC2086
-RUN \
-    apt-get update && apt-get install -y --no-install-recommends --no-install-suggests \
-        # Can uninstall before build
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends --no-install-suggests \
         apt-transport-https \
         curl \
         gnupg \
-        # Needed for FF to run
         aspnetcore-runtime-8.0 \
         ca-certificates \
         catatonit \
         libfontconfig1 \
         libfreetype6 \
         pciutils \
-    # Intel HW
-    if [ "${TARGETARCH}" = "amd64" ]; then \
-      mkdir -p /tmp/intel-compute-runtime && cd /tmp/intel-compute-runtime \
-      && curl -LO https://github.com/intel/compute-runtime/releases/download/25.13.33276.16/libigdgmm12_22.7.0_amd64.deb \
-      && curl -LO https://github.com/intel/intel-graphics-compiler/releases/download/v2.11.7/intel-igc-core-2_2.11.7+19146_amd64.deb \
-      && curl -LO https://github.com/intel/intel-graphics-compiler/releases/download/v2.11.7/intel-igc-opencl-2_2.11.7+19146_amd64.deb \
-      && curl -LO https://github.com/intel/compute-runtime/releases/download/25.13.33276.16/intel-opencl-icd_25.13.33276.16_amd64.deb \
-      && dpkg -i --force-all ./*.deb \
-      && cd /; \
+    && if [ "${TARGETARCH}" = "amd64" ]; then \
+        mkdir -p /tmp/intel-compute-runtime && cd /tmp/intel-compute-runtime && \
+        curl -LO https://github.com/intel/compute-runtime/releases/download/25.13.33276.16/libigdgmm12_22.7.0_amd64.deb && \
+        curl -LO https://github.com/intel/intel-graphics-compiler/releases/download/v2.11.7/intel-igc-core-2_2.11.7+19146_amd64.deb && \
+        curl -LO https://github.com/intel/intel-graphics-compiler/releases/download/v2.11.7/intel-igc-opencl-2_2.11.7+19146_amd64.deb && \
+        curl -LO https://github.com/intel/compute-runtime/releases/download/25.13.33276.16/intel-opencl-icd_25.13.33276.16_amd64.deb && \
+        dpkg -i --force-all ./*.deb && \
+        cd /; \
     fi \
-    # Install ffmpeg
     && VERSION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d= -f2) \
     && curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key \
         | gpg --dearmor -o /etc/apt/trusted.gpg.d/jellyfin_team.gpg \
@@ -89,21 +85,18 @@ RUN \
     && apt-get update \
     && apt-get install -y --no-install-recommends --no-install-suggests \
         jellyfin-ffmpeg7 \
-    # ffmpeg link
     && ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/local/bin/ffmpeg \
     && ln -s /usr/lib/jellyfin-ffmpeg/ffmpeg /usr/local/bin/ffmpeg7 \
     && ln -s /usr/lib/jellyfin-ffmpeg/ffprobe /usr/local/bin/ffprobe \
-    # Clean up unnecessary packages
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
         apt-transport-https \
         curl \
         gnupg \
     && apt-get autoremove -y \
     && apt-get clean \
-    # Clean up image
     && rm -rf /var/lib/apt/lists/* /tmp/* \
-    # i18n hack
     && mkdir -p /var/tmp/i18n && mv /app/Server/wwwroot/i18n/* /var/tmp/i18n
+
 
 COPY . /
 RUN chmod +x /entrypoint.sh

--- a/apps/fileflows/Dockerfile
+++ b/apps/fileflows/Dockerfile
@@ -71,14 +71,14 @@ RUN \
         libfreetype6 \
         pciutils \
     # Intel HW
-    if [ "${TARGETARCH}" = "amd64" ] then \
+    if [ "${TARGETARCH}" = "amd64" ]; then \
       mkdir -p /tmp/intel-compute-runtime && cd /tmp/intel-compute-runtime \
       && curl -LO https://github.com/intel/compute-runtime/releases/download/25.13.33276.16/libigdgmm12_22.7.0_amd64.deb \
       && curl -LO https://github.com/intel/intel-graphics-compiler/releases/download/v2.11.7/intel-igc-core-2_2.11.7+19146_amd64.deb \
       && curl -LO https://github.com/intel/intel-graphics-compiler/releases/download/v2.11.7/intel-igc-opencl-2_2.11.7+19146_amd64.deb \
       && curl -LO https://github.com/intel/compute-runtime/releases/download/25.13.33276.16/intel-opencl-icd_25.13.33276.16_amd64.deb \
       && dpkg -i --force-all ./*.deb \
-      && cd / \
+      && cd /; \
     fi \
     # Install ffmpeg
     && VERSION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d= -f2) \

--- a/apps/fileflows/Dockerfile
+++ b/apps/fileflows/Dockerfile
@@ -69,11 +69,11 @@ RUN apt-get update \
         libfreetype6 \
         pciutils \
     && if [ "${TARGETARCH}" = "amd64" ]; then \
-        mkdir -p /tmp/intel-compute-runtime && cd /tmp/intel-compute-runtime && \
-        curl -LO https://github.com/intel/compute-runtime/releases/download/25.13.33276.16/libigdgmm12_22.7.0_amd64.deb && \
-        curl -LO https://github.com/intel/intel-graphics-compiler/releases/download/v2.11.7/intel-igc-core-2_2.11.7+19146_amd64.deb && \
-        curl -LO https://github.com/intel/intel-graphics-compiler/releases/download/v2.11.7/intel-igc-opencl-2_2.11.7+19146_amd64.deb && \
-        curl -LO https://github.com/intel/compute-runtime/releases/download/25.13.33276.16/intel-opencl-icd_25.13.33276.16_amd64.deb && \
+        mkdir -p /tmp/intel-compute-runtime && cd /tmp/intel-compute-runtime \
+        && curl -LO https://github.com/intel/compute-runtime/releases/download/25.13.33276.16/libigdgmm12_22.7.0_amd64.deb \
+        && curl -LO https://github.com/intel/intel-graphics-compiler/releases/download/v2.11.7/intel-igc-core-2_2.11.7+19146_amd64.deb \
+        && curl -LO https://github.com/intel/intel-graphics-compiler/releases/download/v2.11.7/intel-igc-opencl-2_2.11.7+19146_amd64.deb \
+        && curl -LO https://github.com/intel/compute-runtime/releases/download/25.13.33276.16/intel-opencl-icd_25.13.33276.16_amd64.deb \
         && apt-get install -y --no-install-recommends --no-install-suggests \
             ./libigdgmm12_22.7.0_amd64.deb \
             ./intel-igc-core-2_2.11.7+19146_amd64.deb \

--- a/apps/fileflows/Dockerfile
+++ b/apps/fileflows/Dockerfile
@@ -69,17 +69,12 @@ RUN apt-get update \
         libfreetype6 \
         pciutils \
     && if [ "${TARGETARCH}" = "amd64" ]; then \
-        mkdir -p /tmp/intel-compute-runtime && cd /tmp/intel-compute-runtime \
-        && curl -LO https://github.com/intel/compute-runtime/releases/download/25.13.33276.16/libigdgmm12_22.7.0_amd64.deb \
-        && curl -LO https://github.com/intel/intel-graphics-compiler/releases/download/v2.11.7/intel-igc-core-2_2.11.7+19146_amd64.deb \
-        && curl -LO https://github.com/intel/intel-graphics-compiler/releases/download/v2.11.7/intel-igc-opencl-2_2.11.7+19146_amd64.deb \
-        && curl -LO https://github.com/intel/compute-runtime/releases/download/25.13.33276.16/intel-opencl-icd_25.13.33276.16_amd64.deb \
-        && apt-get install -y --no-install-recommends --no-install-suggests \
-            ./libigdgmm12_22.7.0_amd64.deb \
-            ./intel-igc-core-2_2.11.7+19146_amd64.deb \
-            ./intel-igc-opencl-2_2.11.7+19146_amd64.deb \
-            ./intel-opencl-icd_25.13.33276.16_amd64.deb \
-        cd /; \
+        mkdir -p /tmp/intel-compute-runtime \
+        && curl -Lo /tmp/intel-compute-runtime/libigdgmm.deb https://github.com/intel/compute-runtime/releases/download/25.13.33276.16/libigdgmm12_22.7.0_amd64.deb \
+        && curl -Lo /tmp/intel-compute-runtime/intel-igc-core.deb https://github.com/intel/intel-graphics-compiler/releases/download/v2.11.7/intel-igc-core-2_2.11.7+19146_amd64.deb \
+        && curl -Lo /tmp/intel-compute-runtime/intel-igc-opencl.deb https://github.com/intel/intel-graphics-compiler/releases/download/v2.11.7/intel-igc-opencl-2_2.11.7+19146_amd64.deb \
+        && curl -Lo /tmp/intel-compute-runtime/intel-opencl-icd.deb https://github.com/intel/compute-runtime/releases/download/25.13.33276.16/intel-opencl-icd_25.13.33276.16_amd64.deb \
+        && apt-get install -y --no-install-recommends /tmp/intel-compute-runtime/*.deb; \
     fi \
     && VERSION_CODENAME=$(grep VERSION_CODENAME /etc/os-release | cut -d= -f2) \
     && curl -fsSL https://repo.jellyfin.org/jellyfin_team.gpg.key \

--- a/apps/fileflows/tests.yaml
+++ b/apps/fileflows/tests.yaml
@@ -26,6 +26,9 @@ command:
     exit-status: 0
     stdout:
       - '/^.+$/'
+  # Ensure libva2 is > 2.20.0
+  "dpkg --compare-versions $(dpkg-query -W -f='${Version}' libva2) gt 2.20.0":
+    exit-status: 0
 file:
   /app/Data/Data/FileFlows.sqlite:
     exists: true


### PR DESCRIPTION
"Cant process '/usr/local/bin/ffmpeg -fflags +genpts -vaapi_device /dev/dri/renderD128 -loglevel error -f lavfi -i color=black:s=1080x1080 -vframes 1 -an -c:v hevc_vaapi -vf format=nv12,hwupload -strict -2 /temp/Runner-395fa554-c1fe-41e1-9cfe-b8a01a21c914/6919eeed-e890-4789-bc35-c6014ebbda91.mkv': /usr/local/bin/ffmpeg: symbol lookup error: /usr/lib/jellyfin-ffmpeg/lib/libavutil.so.59: undefined symbol: vaMapBuffer2"