### PR TITLE
fix(fileflows) add btbn

### DIFF
--- a/apps/fileflows/Dockerfile
+++ b/apps/fileflows/Dockerfile
@@ -1,5 +1,9 @@
 # syntax=docker/dockerfile:1
 
+# Placeholders to use with variable sub
+FROM ghcr.io/btbn/ffmpeg-builds/linux64-gpl:latest AS ffmpeg-amd64
+FROM ghcr.io/btbn/ffmpeg-builds/linuxarm64-gpl:latest AS ffmpeg-arm64
+
 FROM docker.io/library/alpine:3.22.0 AS fileflows-download
 ARG VERSION
 
@@ -48,6 +52,9 @@ USER root
 WORKDIR /app
 
 COPY --from=fileflows-download /app /app
+# btbn for fileflows ffmpeg (new default)
+COPY --from=ffmpeg-${TARGETARCH} /usr/local/bin/ffmpeg  /app/common/ffmpeg-static/ffmpeg
+COPY --from=ffmpeg-${TARGETARCH} /usr/local/bin/ffprobe /app/common/ffmpeg-static/ffprobe
 
 # hadolint ignore=DL3008,DL3015,SC2039,SC2086
 RUN \


### PR DESCRIPTION
Version 25.06.3 added vmaf which needs btbn's ffmpeg build. Installing to /app/common as the upstream does
https://github.com/revenz/FileFlowsRepository/blob/master/DockerMods/FFmpeg-FileFlows-Edition.sh